### PR TITLE
Change tox link from tox.im to tox.chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Secure sharing software for messages, forums and chats.
 * [**Bitmessage**](https://bitmessage.org/wiki/Main_Page)
 Send encrypted messages to another person or to many subscribers.
 
-* [**Tox**](https://tox.im/)
+* [**Tox**](https://tox.chat/)
 Secure & open-source instant messaging.
 
 * [**Bleep**](http://www.bleep.pm/)


### PR DESCRIPTION
The tox project's official domain is tox.chat. tox.im just links to a blog post from a developer who is no longer affiliated with the project.